### PR TITLE
Feat: support format flags with unsafe optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
 name = "pretty_decimal"
 version = "0.1.2"
 dependencies = [
+ "arrayvec",
  "bounded-static",
  "criterion",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 description = "library for Decimal type with pretty printing."
 
 [dependencies]
+arrayvec = "0.7.6"
 bounded-static = { version = "0.8", default-features = false, features = ["derive"], optional = true}
 itoa = "1.0.15"
 rust_decimal = "1.37.2"


### PR DESCRIPTION
Now `PrettyDecimal` supports formatting flag.

To compensate the performance penalty introduced by this change,
this PR also introduced unsafe optimizations assuming encoded string from itoa is ASCII thus all valid UTF-8 byte sequence.