### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@
 
 ### Fixed
 
-## [0.1.3] - 2025-07-18
+## [0.2.0] - 2025-07-18
 
 ### Added
 
 * New API to construct value with format (https://github.com/xkikeg/pretty-decimal/pull/10).
 * Supported formatting options (https://github.com/xkikeg/pretty-decimal/pull/7).
+
+### Changed
+
+* Renamed `Error` type to `ParseError`.
 
 ## [0.1.2] - 2025-07-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pretty_decimal"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "library for Decimal type with pretty printing."


### PR DESCRIPTION
We've changed the type name, which requires major release.