### PR TITLE
Remove periodical executions from CI.

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
-    - cron: '0 6 * * *'
 
 jobs:
   msrv:


### PR DESCRIPTION
Repository isn't that active, no need to run periodically.